### PR TITLE
Add leaflet-draw dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2515,6 +2515,13 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
     },
+    "node_modules/leaflet-draw": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
+      "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ==",
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/leaflet.markercluster": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2515,13 +2515,6 @@
       "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
       "license": "BSD-2-Clause"
     },
-    "node_modules/leaflet-draw": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
-      "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ==",
-      "license": "MIT",
-      "peer": true
-    },
     "node_modules/leaflet.markercluster": {
       "version": "1.5.3",
       "resolved": "https://registry.npmjs.org/leaflet.markercluster/-/leaflet.markercluster-1.5.3.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "axios": "^1.9.0",
         "leaflet": "^1.9.4",
+        "leaflet-draw": "^1.0.4",
         "lucide-react": "^0.511.0",
         "ol": "^10.5.0",
         "prop-types": "^15.8.1",
@@ -2519,8 +2520,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/leaflet-draw/-/leaflet-draw-1.0.4.tgz",
       "integrity": "sha512-rsQ6saQO5ST5Aj6XRFylr5zvarWgzWnrg46zQ1MEOEIHsppdC/8hnN8qMoFvACsPvTioAuysya/TVtog15tyAQ==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/leaflet.markercluster": {
       "version": "1.5.3",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "axios": "^1.9.0",
     "leaflet": "^1.9.4",
+    "leaflet-draw": "^1.0.4",
     "lucide-react": "^0.511.0",
     "ol": "^10.5.0",
     "prop-types": "^15.8.1",


### PR DESCRIPTION
Add leaflet-draw package as a direct dependency.

Changes:
- Added leaflet-draw ^1.0.4 to package.json dependencies
- Removed "peer": true flag from leaflet-draw in package-lock.json
- Updated package-lock.json to reflect the new dependency structure

tag @builderio-bot for anything you want the bot to do

To clone this PR locally use the [Github CLI](https://cli.github.com/) with command `gh pr checkout 1`

🔗 [Edit in Builder.io](https://builder.io/app/projects/bac51e9e032e4daeb4060091bf7f4c30/mystic-space)

<!-- DO NOT EDIT THE CONTENT BELOW: -->
<!--<projectId>bac51e9e032e4daeb4060091bf7f4c30</projectId>-->
<!--<branchName>mystic-space</branchName>-->